### PR TITLE
fix: nil defaults for proxy_addr & proxy_port

### DIFF
--- a/lib/EnvironmentVariables.rb
+++ b/lib/EnvironmentVariables.rb
@@ -7,8 +7,8 @@ module CnpOnline
       @currency_merchant_map = ''
       @default_report_group = 'Default Report Group'
       @url = ''
-      @proxy_addr = ''
-      @proxy_port = ''
+      @proxy_addr = nil
+      @proxy_port = nil
       @sftp_username = ''
       @sftp_password = ''
       @sftp_url = ''


### PR DESCRIPTION
Modifies the default values for proxy_addr and proxy_port to be nil
instead of blank strings.  This ensures that Net::HTTP doesn't
interpret them as meaningful values if not specified.

Fixes #1 