### PR TITLE
Jdl/pde 1622 worldpay host change

### DIFF
--- a/cnp_online.gemspec
+++ b/cnp_online.gemspec
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'CnpOnline'
+  spec.version       = CnpOnline::VERSION
+  spec.authors       = ['Ryan Kortmann']
+  spec.email         = ['ryan.kortmann@food52.com']
+  spec.summary       = 'Food52 Forked version of CnpOnline from Vantiv/WorldPay'
+  spec.description   = 'A wrapper for the Vantiv/WorldPay CnpOnline API'
+  spec.homepage      = 'https://github.com/food52/cnp-sdk-for-ruby'
+  spec.platform      = Gem::Platform::RUBY
+  spec.license       = 'MIT'
+
+  spec.files         = Dir['**/**']
+  spec.executables   = ['sample_driver.rb', 'Setup.rb']
+  spec.test_files    = Dir['test/unit/ts_unit.rb']
+
+  spec.add_dependency('xml-object')
+  spec.add_dependency('xml-mapping')
+  spec.add_dependency('net-sftp')
+  spec.add_dependency('libxml-ruby')
+  spec.add_dependency('crack')
+  spec.add_dependency('iostreams')
+  spec.add_development_dependency('mocha')
+end

--- a/cnp_online.gemspec
+++ b/cnp_online.gemspec
@@ -6,7 +6,7 @@ require 'version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'CnpOnline'
-  spec.version       = CnpOnline::VERSION
+  spec.version       = '12.7.0'
   spec.authors       = ['Ryan Kortmann']
   spec.email         = ['ryan.kortmann@food52.com']
   spec.summary       = 'Food52 Forked version of CnpOnline from Vantiv/WorldPay'

--- a/lib/CnpBatchRequest.rb
+++ b/lib/CnpBatchRequest.rb
@@ -29,9 +29,9 @@ require_relative 'Configuration'
 module CnpOnline
   class CnpBatchRequest
     include XML::Mapping
-    def initialize ()
+    def initialize(config_hash = {})
       #load configuration data
-      @config_hash = Configuration.new.config
+      @config_hash = Configuration.new.config.merge(config_hash)
 
       @txn_counts = { :id=>nil,
         :merchantId=>nil,
@@ -634,9 +634,9 @@ module CnpOnline
 
   class CnpAUBatch
     include XML::Mapping
-    def initialize
+    def initialize(config_hash = {})
       #load configuration data
-      @config_hash = Configuration.new.config
+      @config_hash = Configuration.new.config.merge(config_hash)
 
       @txn_counts = { :id=>nil,
         :merchantId=>nil,

--- a/lib/CnpOnlineRequest.rb
+++ b/lib/CnpOnlineRequest.rb
@@ -30,9 +30,9 @@ require_relative 'Configuration'
 module CnpOnline
 
   class CnpOnlineRequest
-    def initialize
+    def initialize(config_hash = {})
       #load configuration data
-      @config_hash = Configuration.new.config
+      @config_hash = Configuration.new.config.merge(config_hash)
       @cnp_transaction = CnpTransaction.new
     end
 

--- a/lib/CnpOnlineRequest.rb
+++ b/lib/CnpOnlineRequest.rb
@@ -295,7 +295,7 @@ module CnpOnline
 
       request.authentication  = authentication
       request.merchantId      = get_merchant_id(options)
-      request.version         = '12.3'
+      request.version         = '12.7'
       request.loggedInUser    = get_logged_in_user(options)
       request.xmlns           = "http://www.vantivcnp.com/schema"
       request.merchantSdk     = get_merchant_sdk(options)
@@ -325,7 +325,7 @@ module CnpOnline
     end
 
     def get_merchant_sdk(options)
-      options['merchantSdk'] || 'Ruby;12.3'
+      options['merchantSdk'] || 'Ruby;12.7'
     end
 
     def get_report_group(options)

--- a/lib/CnpRequest.rb
+++ b/lib/CnpRequest.rb
@@ -207,7 +207,7 @@ module CnpOnline
       cnpRequest.authentication = authentication
       cnpRequest.numBatchRequests = "0"
       
-      cnpRequest.version         = '12.3'
+      cnpRequest.version         = '12.7'
       cnpRequest.xmlns           = "http://www.vantivcnp.com/schema"
 
       
@@ -459,7 +459,7 @@ module CnpOnline
       authentication.password = get_config(:password, options)
 
       cnp_request.authentication = authentication
-      cnp_request.version         = '12.3'
+      cnp_request.version         = '12.7'
       cnp_request.xmlns           = "http://www.vantivcnp.com/schema"
       # cnp_request.id              = options['sessionId'] #grab from options; okay if nil
       cnp_request.numBatchRequests = @num_batch_requests

--- a/lib/CnpRequest.rb
+++ b/lib/CnpRequest.rb
@@ -52,9 +52,9 @@ COMPLETE_FILE_SUFFIX = '.complete'
 module CnpOnline
   class CnpRequest
     include XML::Mapping
-    def initialize(options = {})
+    def initialize(options = {}, config_hash = {})
       #load configuration data
-      @config_hash = Configuration.new.config
+      @config_hash = Configuration.new.config.merge(config_hash)
       @num_batch_requests = 0
       @path_to_request = ""
       @path_to_batches = ""

--- a/lib/Communications.rb
+++ b/lib/Communications.rb
@@ -50,8 +50,16 @@ module CnpOnline
         https.verify_mode = ssl_verify_mode
         https.ca_file = File.join(File.dirname(__FILE__), "cacert.pem")
       end
+      
+      if !Rails.env.production?
+        host = 'online.vantivcnp.com'
+      else
+        host = 'services.vantivprelive.com'
+      end 
+
       https.start { |http|
-        response = http.request_post(url.path, post_data.to_s, {'Content-Type'=>'text/xml; charset=UTF-8','Connection'=>'close'})
+        response = http.request_post(url.path, post_data.to_s, {'Content-Type'=>'text/xml; charset=UTF-8',
+          'Connection'=>'close', 'host' => host})
         response_xml = response
       }
   

--- a/lib/Communications.rb
+++ b/lib/Communications.rb
@@ -38,6 +38,7 @@ module CnpOnline
       proxy_addr = config_hash['proxy_addr']
       proxy_port = config_hash['proxy_port']
       cnp_url = config_hash['url']
+      ssl_verify_mode = config_hash['ssl_verify_mode'] || OpenSSL::SSL::VERIFY_PEER
   
       # setup https or http post
       url = URI.parse(cnp_url)
@@ -46,7 +47,7 @@ module CnpOnline
       https = Net::HTTP.new(url.host, url.port, proxy_addr, proxy_port)
       if(url.scheme == 'https') 
         https.use_ssl = url.scheme=='https'
-        https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        https.verify_mode = ssl_verify_mode
         https.ca_file = File.join(File.dirname(__FILE__), "cacert.pem")
       end
       https.start { |http|

--- a/lib/Communications.rb
+++ b/lib/Communications.rb
@@ -54,7 +54,7 @@ module CnpOnline
       if !Rails.env.production?
         host = 'online.vantivcnp.com'
       else
-        host = 'services.vantivprelive.com'
+        host = 'online.vantivprelive.com'
       end 
 
       https.start { |http|

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module CnpOnline
+  VERSION = '12.3.0'
+end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CnpOnline
-  VERSION = '12.3.0'
+  VERSION = '12.7.0'
 end


### PR DESCRIPTION
As per https://food52.atlassian.net/browse/PDE-1622

Changing request headers `host` to use `online.vantivcnp.com` / `online.vantivprelive.com` for Worldpay. 